### PR TITLE
[PLATFO-4604] - Adicionar módulo para o resouce aws_dms_s3_endpoint

### DIFF
--- a/modules/endpoints_s3/README.md
+++ b/modules/endpoints_s3/README.md
@@ -1,0 +1,43 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_dms_s3_endpoint.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_s3_endpoint) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_certificate_arn"></a> [certificate\_arn](#input\_certificate\_arn) | (Optional, Default: empty string) The Amazon Resource Name (ARN) for the certificate. | `string` | `""` | no |
+| <a name="input_create"></a> [create](#input\_create) | (Opcional) Used to create the Data Migration Service | `bool` | `false` | no |
+| <a name="input_endpoint_id"></a> [endpoint\_id](#input\_endpoint\_id) | (Required) The database endpoint identifier. | `string` | `""` | no |
+| <a name="input_endpoint_type"></a> [endpoint\_type](#input\_endpoint\_type) | (Required) The type of endpoint. Can be one of source \| target | `string` | `"source"` | no |
+| <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | (Required when engine\_name is mongodb, optional otherwise) | `string` | `""` | no |
+| <a name="input_s3_settings"></a> [s3\_settings](#input\_s3\_settings) | (Optional) Configuration block with S3 settings. Detailed below. | `any` | `{}` | no |
+| <a name="input_ssl_mode"></a> [ssl\_mode](#input\_ssl\_mode) | Optional, Default: none) The SSL mode to use for the connection. Can be one of none \| require \| verify-ca \| verify-full | `string` | `"none"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A map of tags to assign to the resource. | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_certificate_arn"></a> [certificate\_arn](#output\_certificate\_arn) | Certificate ARN |
+| <a name="output_endpoint_arn"></a> [endpoint\_arn](#output\_endpoint\_arn) | Endpoint ARN |
+| <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | KMS key ARN |
+| <a name="output_ssl_mode"></a> [ssl\_mode](#output\_ssl\_mode) | SSL mode |
+<!-- END_TF_DOCS -->

--- a/modules/endpoints_s3/main.tf
+++ b/modules/endpoints_s3/main.tf
@@ -1,0 +1,29 @@
+resource "aws_dms_s3_endpoint" "this" {
+  count = var.create ? 1 : 0
+
+  certificate_arn = var.certificate_arn
+  endpoint_type   = var.endpoint_type
+  endpoint_id     = "${var.endpoint_id}-${var.endpoint_type}"
+  ssl_mode        = var.ssl_mode
+  kms_key_arn     = var.kms_key_arn
+
+  bucket_name = var.s3_settings[0]["bucket_name"]
+
+  bucket_folder                    = lookup(var.s3_settings[0], "bucket_folder", null)
+  external_table_definition        = lookup(var.s3_settings[0], "external_table_definition", null)
+  service_access_role_arn          = lookup(var.s3_settings[0], "service_access_role_arn", null)
+  compression_type                 = lookup(var.s3_settings[0], "compression_type", "NONE")
+  csv_delimiter                    = lookup(var.s3_settings[0], "csv_delimiter", ",")
+  csv_row_delimiter                = lookup(var.s3_settings[0], "csv_row_delimiter", null)
+  date_partition_enabled           = lookup(var.s3_settings[0], "date_partition_enabled", false)
+  data_format                      = lookup(var.s3_settings[0], "data_format", "csv")
+  date_partition_delimiter         = lookup(var.s3_settings[0], "date_partition_delimiter", "NONE")
+  date_partition_sequence          = lookup(var.s3_settings[0], "date_partition_sequence", "YYYYMMDD")
+  include_op_for_full_load         = lookup(var.s3_settings[0], "include_op_for_full_load", false)
+  parquet_timestamp_in_millisecond = lookup(var.s3_settings[0], "parquet_timestamp_in_millisecond", false)
+  parquet_version                  = lookup(var.s3_settings[0], "parquet_version", "parquet-1-0")
+  enable_statistics                = lookup(var.s3_settings[0], "enable_statistics", true)
+  preserve_transactions            = lookup(var.s3_settings[0], "preserve_transactions", false)
+
+  tags = var.tags
+}

--- a/modules/endpoints_s3/output.tf
+++ b/modules/endpoints_s3/output.tf
@@ -1,0 +1,19 @@
+output "endpoint_arn" {
+  description = "Endpoint ARN"
+  value       = aws_dms_s3_endpoint.this[0].endpoint_arn
+}
+
+output "certificate_arn" {
+  description = "Certificate ARN"
+  value       = aws_dms_s3_endpoint.this[0].certificate_arn
+}
+
+output "kms_key_arn" {
+  description = "KMS key ARN"
+  value       = aws_dms_s3_endpoint.this[0].kms_key_arn
+}
+
+output "ssl_mode" {
+  description = "SSL mode"
+  value       = aws_dms_s3_endpoint.this[0].ssl_mode
+}

--- a/modules/endpoints_s3/variables.tf
+++ b/modules/endpoints_s3/variables.tf
@@ -1,0 +1,47 @@
+variable "create" {
+  description = "(Opcional) Used to create the Data Migration Service"
+  type        = bool
+  default     = false
+}
+
+variable "certificate_arn" {
+  description = "(Optional, Default: empty string) The Amazon Resource Name (ARN) for the certificate."
+  type        = string
+  default     = ""
+}
+
+variable "endpoint_type" {
+  description = "(Required) The type of endpoint. Can be one of source | target"
+  type        = string
+  default     = "source"
+}
+
+variable "endpoint_id" {
+  description = "(Required) The database endpoint identifier."
+  type        = string
+  default     = ""
+}
+
+variable "ssl_mode" {
+  description = "Optional, Default: none) The SSL mode to use for the connection. Can be one of none | require | verify-ca | verify-full"
+  type        = string
+  default     = "none"
+}
+
+variable "kms_key_arn" {
+  description = "(Required when engine_name is mongodb, optional otherwise)"
+  type        = string
+  default     = ""
+}
+
+variable "s3_settings" {
+  description = "(Optional) Configuration block with S3 settings. Detailed below."
+  type        = any
+  default     = {}
+}
+
+variable "tags" {
+  description = "(Optional) A map of tags to assign to the resource."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
# Objetivo 
Estamos incluindo um módulo para o resource [aws_dms_s3_endpoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_s3_endpoint) como alternativa sugerida e reportada na [issue](https://github.com/hashicorp/terraform-provider-aws/issues/27283) 

```sh
aws_dms_replication_task failed with error InvalidParameterValueException: 
   TimestampColumnName cannot be an empty string.
```

Esse módulo ira destravar a criação de novas tasks no DMS. Mais detalhes podem ser encontrado no PR https://github.com/getninjas/.terraform/pull/541